### PR TITLE
Removing the need for the user creds on scan

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Bots/ABotRule.cs
+++ b/src/Nullinside.Api.TwitchBot/Bots/ABotRule.cs
@@ -31,12 +31,11 @@ public abstract class ABotRule : IBotRule {
   /// <remarks>This should only be called if <see cref="ShouldRun" /> returns true.</remarks>
   /// <param name="user">The user.</param>
   /// <param name="config">The user's configuration.</param>
-  /// <param name="userProxy">The twitch api authenticated as the user we're scanning.</param>
   /// <param name="botProxy">The twitch api authenticated as the bot user.</param>
   /// <param name="db">The database.</param>
   /// <param name="stoppingToken">The cancellation token.</param>
   /// <returns>An asynchronous task.</returns>
-  public abstract Task Handle(User user, TwitchUserConfig config, TwitchApiProxy userProxy, TwitchApiProxy botProxy,
+  public abstract Task Handle(User user, TwitchUserConfig config, TwitchApiProxy botProxy,
     NullinsideContext db, CancellationToken stoppingToken = new());
 
   /// <summary>

--- a/src/Nullinside.Api.TwitchBot/Bots/BanKnownBots.cs
+++ b/src/Nullinside.Api.TwitchBot/Bots/BanKnownBots.cs
@@ -67,12 +67,11 @@ public class BanKnownBots : ABotRule {
   /// </summary>
   /// <param name="user">The user.</param>
   /// <param name="config">The user's configuration.</param>
-  /// <param name="userProxy">The twitch api authenticated as the user we're scanning.</param>
   /// <param name="botProxy">The twitch api authenticated as the bot user.</param>
   /// <param name="db">The database.</param>
   /// <param name="stoppingToken">The cancellation token.</param>
-  public override async Task Handle(User user, TwitchUserConfig config, TwitchApiProxy userProxy,
-    TwitchApiProxy botProxy, NullinsideContext db, CancellationToken stoppingToken = new()) {
+  public override async Task Handle(User user, TwitchUserConfig config, TwitchApiProxy botProxy,
+    NullinsideContext db, CancellationToken stoppingToken = new()) {
     if (null == user.TwitchId) {
       return;
     }

--- a/src/Nullinside.Api.TwitchBot/Bots/IBotRule.cs
+++ b/src/Nullinside.Api.TwitchBot/Bots/IBotRule.cs
@@ -27,11 +27,10 @@ public interface IBotRule {
   /// <remarks>This should only be called if <see cref="ShouldRun" /> returns true.</remarks>
   /// <param name="user">The user.</param>
   /// <param name="config">The user's configuration.</param>
-  /// <param name="userProxy">The twitch api authenticated as the user we're scanning.</param>
   /// <param name="botProxy">The twitch api authenticated as the bot user.</param>
   /// <param name="db">The database.</param>
   /// <param name="stoppingToken">The cancellation token.</param>
   /// <returns>An asynchronous task.</returns>
-  public Task Handle(User user, TwitchUserConfig config, TwitchApiProxy userProxy, TwitchApiProxy botProxy,
+  public Task Handle(User user, TwitchUserConfig config, TwitchApiProxy botProxy,
     NullinsideContext db, CancellationToken stoppingToken = new());
 }


### PR DESCRIPTION
Later on we will need to add this back. We have about ~633 users from the previous iteration of the bot that I would like to re-introduce. In order to do that we need to not have their token and only use the bot's token. For now, we do this. Later on when we need their creds for something we can put a message in their channel to re-authenticate.