### PR TITLE
Fixing logging of banned users

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Bots/ABotRule.cs
+++ b/src/Nullinside.Api.TwitchBot/Bots/ABotRule.cs
@@ -86,10 +86,10 @@ public abstract class ABotRule : IBotRule {
 
     db.TwitchUser.UpdateRange(nonExistantUsers);
     db.TwitchBan
-      .AddRange(confirmedBans
+      .AddRange(possibleBans
         .Select(i => new TwitchBan {
           ChannelId = channelId,
-          BannedUserTwitchId = i.UserId,
+          BannedUserTwitchId = i,
           Reason = reason,
           Timestamp = DateTime.UtcNow
         }));

--- a/src/Nullinside.Api.TwitchBot/Services/MainService.cs
+++ b/src/Nullinside.Api.TwitchBot/Services/MainService.cs
@@ -127,7 +127,7 @@ public class MainService : BackgroundService {
               }
             });
 
-            await Task.Delay(1000, stoppingToken);
+            await Task.Delay(10000, stoppingToken);
           }
         }
       }


### PR DESCRIPTION
We need to log failed bans as well. In ye-olden days you could ban someone twice or try to ban a mod and twitch would just do nothing and say nothing about it. Now they actually cause an error to be thrown. We don't want to ban people over and over and over again when they can't be banned.