### PR TITLE
Reducing MySQL Error Logging

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Services/MainService.cs
+++ b/src/Nullinside.Api.TwitchBot/Services/MainService.cs
@@ -117,6 +117,7 @@ public class MainService : BackgroundService {
         }
         catch (Exception ex) {
           _log.LogError(ex, "Main Failed");
+          await Task.Delay(TimeSpan.FromSeconds(10));
         }
       }
     }, stoppingToken);


### PR DESCRIPTION
When the MYSQL server is down, the loop would go crazy pouring error messages and stack traces into grafana. To the point where the dashboard would stop working.

This reduces the spam by giving the server a few seconds to come back up before we try again.