### PR TITLE
Adding testing endpoint

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Controllers/TwitchWebHookController.cs
+++ b/src/Nullinside.Api.TwitchBot/Controllers/TwitchWebHookController.cs
@@ -25,8 +25,10 @@ public class TwitchWebHookController : ControllerBase {
   /// <returns></returns>
   [HttpPost]
   [Route("chat")]
-  public IActionResult TwitchChatMessageCallback(string stuff, CancellationToken token) {
-    _log.Info(stuff);
+  public async Task<IActionResult> TwitchChatMessageCallback(CancellationToken token) {
+    using StreamReader stream = new StreamReader(this.HttpContext.Request.Body);
+    string stuff = await stream.ReadToEndAsync(token);
+    _log.Info($"TwitchChatMessageCallback: {stuff}");
     return Ok(true);
   }
 }


### PR DESCRIPTION
    The twitch webhooks API requires a publicly available endpoint that is
    protected by a valid SSL certificate. We will put this testing endpoint
    up so we can start building out a chat subscription endpoint