### PR TITLE
Updating chat client with new OAuth token after refresh

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Services/MainService.cs
+++ b/src/Nullinside.Api.TwitchBot/Services/MainService.cs
@@ -162,6 +162,9 @@ public class MainService : BackgroundService {
 
             ITwitchApiProxy? botApi = await db.ConfigureApiAndRefreshToken(botUser, this._api, stoppingToken);
             if (null != botApi) {
+              // Ensure the twitch client has the most up-to-date password
+              this._client.TwitchOAuthToken = botApi.OAuth?.AccessToken;
+              
               // Trim channels that aren't live
               IEnumerable<string> liveUsers = await botApi.GetChannelsLive(usersWithBotEnabled
                 .Where(u => null != u.TwitchId)


### PR DESCRIPTION
Assuming the rest of the code is behaving properly, in terms of knowing whether or not the chat client is connected, simply updating the token should keep up connected.

#43 