### PR TITLE
fix: fixing possible duplicate insertion

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Model/NullinsideContextExtensions.cs
+++ b/src/Nullinside.Api.TwitchBot/Model/NullinsideContextExtensions.cs
@@ -161,7 +161,7 @@ public static class NullinsideContextExtensions {
   /// <param name="stoppingToken">The stopping token.</param>
   public static async Task SaveTwitchBans(this INullinsideContext db, string channelId,
     IEnumerable<(string Id, string Username)> bannedUsers, string reason, CancellationToken stoppingToken = new()) {
-    List<string> banUserIds = bannedUsers.Select(b => b.Id).ToList();
+    List<string> banUserIds = bannedUsers.Select(b => b.Id).ToHashSet().ToList();
     HashSet<string?> existingUsers = db.TwitchUser
       .AsNoTracking()
       .Where(u => null != u.TwitchId && banUserIds.Contains(u.TwitchId))


### PR DESCRIPTION
Getting errors in the log for duplicate insertions into the TwitchUser table. This is the only place here I can see duplicates.