### PR TITLE
feat: Adding build to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 name: nullinside-api-twitch-bot
 services:
     nullinside-api-twitch-bot:
+        build:
+            context: .
+            tags:
+                - "nullinside-api-twitch-bot:latest"
         logging:
             driver: loki
             options:

--- a/go.sh
+++ b/go.sh
@@ -1,3 +1,3 @@
-docker build -t nullinside-api-twitch-bot:latest .
+docker compose build
 docker compose down
 docker compose up -d


### PR DESCRIPTION
No need to use part regular builds and part docker compose, just in for a penny in for a pound.

nullinside-development-group/nullinside-api#60