### PR TITLE
bug: fixing truncate table issue from 49977e7e733b6f13e5df8ef14e8e92f…

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Services/MainService.cs
+++ b/src/Nullinside.Api.TwitchBot/Services/MainService.cs
@@ -266,7 +266,8 @@ public class MainService : BackgroundService {
     await db.Database.CreateExecutionStrategy().ExecuteAsync(async () => {
       await using IDbContextTransaction transaction = await db.Database.BeginTransactionAsync(stoppingToken).ConfigureAwait(false);
       try {
-        await db.Database.ExecuteSqlRawAsync("TRUNCATE TABLE TwitchUserLive", stoppingToken).ConfigureAwait(false);
+        await db.TwitchUserLive.ExecuteDeleteAsync(stoppingToken).ConfigureAwait(false);
+
         List<TwitchUserLive> liveUsersDbRecords = (
             from s in stream
             let u = users.FirstOrDefault(user => user.TwitchId == s.UserId)


### PR DESCRIPTION
…0275a33c1

In MySQL truncate table isn't transactional, that is to say it implicitly commits a transactions when it is run and therefore cannot be included in transactions.

The table is extremely small, we will simply delete table.