### PR TITLE
feat: adding endpoint to pull recent bot bans

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Controllers/BotController.cs
+++ b/src/Nullinside.Api.TwitchBot/Controllers/BotController.cs
@@ -203,4 +203,26 @@ public class BotController : ControllerBase {
 
     return Ok(currentlyLive.Select(u => new TwitchLiveUsersResponse(u)).ToList());
   }
+
+  /// <summary>
+  ///   Retrieves the list of recently banned bot accounts.
+  /// </summary>
+  [AllowAnonymous]
+  [HttpGet("bans")]
+  [ProducesResponseType(StatusCodes.Status200OK)]
+  public async Task<ObjectResult> GetRecentlyBannedBots(CancellationToken token = new()) {
+    var usernameMapping = await (
+        from u in _dbContext.TwitchUser
+        join b in _dbContext.TwitchBan
+            .OrderByDescending(x => x.Timestamp)
+            .Take(100)
+          on u.TwitchId equals b.BannedUserTwitchId
+        select new { u.TwitchUsername, b.Timestamp }
+      )
+      .Distinct()
+      .ToListAsync(token)
+      .ConfigureAwait(false);
+
+    return Ok(usernameMapping.Select(x => new TwitchRecentBotsResponse(x.TwitchUsername!, x.Timestamp)).ToList());
+  }
 }

--- a/src/Nullinside.Api.TwitchBot/Model/TwitchRecentBotsResponse.cs
+++ b/src/Nullinside.Api.TwitchBot/Model/TwitchRecentBotsResponse.cs
@@ -1,0 +1,26 @@
+namespace Nullinside.Api.TwitchBot.Model;
+
+/// <summary>
+///   A response with information about live Twitch streams.
+/// </summary>
+public class TwitchRecentBotsResponse {
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="TwitchRecentBotsResponse" /> class.
+  /// </summary>
+  /// <param name="twitchUsername">The username of the account.</param>
+  /// <param name="timestamp">The timestamp of the ban.</param>
+  public TwitchRecentBotsResponse(string twitchUsername, DateTime timestamp) {
+    TwitchUsername = twitchUsername;
+    Timestamp = timestamp;
+  }
+
+  /// <summary>
+  ///   The username of the account.
+  /// </summary>
+  public string TwitchUsername { get; set; }
+
+  /// <summary>
+  ///   The timestamp of the ban.
+  /// </summary>
+  public DateTime Timestamp { get; set; }
+}


### PR DESCRIPTION
Adding a method to pull the 100 most recently banned bots.

nullinside-development-group/nullinside-ui#96