### PR TITLE
bug: fixing issue banning incorrect person

### DIFF
--- a/src/Nullinside.Api.TwitchBot.Tests/ChatRules/AChatRuleUnitTestBase.cs
+++ b/src/Nullinside.Api.TwitchBot.Tests/ChatRules/AChatRuleUnitTestBase.cs
@@ -19,6 +19,7 @@ public abstract class AChatRuleUnitTestBase<T> : UnitTestBase where T : AChatRul
   /// <param name="goodString">A friendly string with no issues.</param>
   [Test]
   [TestCase("Hello I love candy and sprinkles")]
+  [TestCase("silver870Silvietwerkin silver870Silvietwerkin silver870Silvietwerkin silver870Silvietwerkin silver870Silvietwerkin silver870Silvietwerkin silver870Silvietwerkin")]
   public async Task TestItDoesntAlwaysFail(string goodString) {
     var rule = new T();
     var botProxy = new Mock<ITwitchApiProxy>();

--- a/src/Nullinside.Api.TwitchBot/ChatRules/BestCheapViewers.cs
+++ b/src/Nullinside.Api.TwitchBot/ChatRules/BestCheapViewers.cs
@@ -29,8 +29,8 @@ public class BestCheapViewers : AChatRule {
     "boosting channels",
     "streaming into the void",
     "get new real viewers",
-    "viewers",
     "top viewers",
+    "viewers *",
     "specialize in promoting twitch channels",
     "stream viewers"
   ];
@@ -48,7 +48,7 @@ public class BestCheapViewers : AChatRule {
     }
 
     // The number of spaces per message may chance, so normalize that and lowercase it for comparison.
-    string normalized = string.Join(' ', message.Message.Split(" ").Where(s => !string.IsNullOrWhiteSpace(s)))
+    string normalized = string.Join(' ', message.Message.Trim().Split(" ").Where(s => !string.IsNullOrWhiteSpace(s)))
       .ToLowerInvariant();
 
     // Messages will be one of two variations with random special characters mixed in. Some of those special characters
@@ -63,7 +63,7 @@ public class BestCheapViewers : AChatRule {
           if (start + i + offset < normalized.Length && normalized[start + i + offset] == expected[i]) {
             ++matches;
           }
-          // If this is an accent mark then the next character should match and the whole string we're evalutating
+          // If this is an accent mark then the next character should match and the whole string we're evaluating
           // will be off by 1 more position.
           else if (start + i + offset + 1 < normalized.Length && normalized[start + i + offset + 1] == expected[i]) {
             ++matches;


### PR DESCRIPTION
Just a stupid thing to do. But other than the bad code, something might be wrong...

The code shouldn't have gotten that far. The user that typed the message added to the AChatRuleUnitTestBase.cs wasn't actually chatting for the first time and yet they passed the first time code. That implies that either twitch sent the wrong info or twitchlib interpreted it wrong when sending it to us.

I checked with a breakpoint and we do, in fact, get false for the IsFirstMessage code and it doesn't seem to be set all the time. However, I saw logs in the database for this user with prior message history and that message still got them banned.