### PR TITLE
bug: working around twitch api issue

### DIFF
--- a/src/Nullinside.Api.TwitchBot/Services/MainService.cs
+++ b/src/Nullinside.Api.TwitchBot/Services/MainService.cs
@@ -202,9 +202,10 @@ public class MainService : BackgroundService {
               // its chat limits so that "verified bots" like us don't get special treatment anymore. The only thing
               // that skips the chat limits is if it's a channel you're a mod in.
               IEnumerable<TwitchModeratedChannel> moddedChannels = await botApi.GetUserModChannels(Constants.BOT_ID).ConfigureAwait(false);
-              usersWithBotEnabled = usersWithBotEnabled
-                .Where(u => moddedChannels.Select(m => m.broadcaster_id).Contains(u.TwitchId))
-                .ToList();
+              // TODO: When the twitch api is fixed we can re-enable this code. Currently there is a bug where twitch doesn't return all mod channels.
+              // usersWithBotEnabled = usersWithBotEnabled
+              //   .Where(u => moddedChannels.Select(m => m.broadcaster_id).Contains(u.TwitchId))
+              //   .ToList();
 
               // If any channels have a different name now, lets update our copy in the database.
               foreach (TwitchModeratedChannel channel in moddedChannels) {


### PR DESCRIPTION
There is something broken in the twitch api. When I attempt to get the list of moderated channels I get random results when asking the api.